### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ A simple collection of helper routines that I use in a lot of projects.
 .. image:: https://requires.io/github/bear/bearlib/requirements.svg?branch=master
     :target: https://requires.io/github/bear/bearlib/requirements/?branch=master
     :alt: Requirements Status
-.. image:: https://pypip.in/wheel/bearlib/badge.png
+.. image:: https://img.shields.io/pypi/wheel/bearlib.svg
     :target: https://pypi.python.org/pypi/bearlib/
     :alt: Wheel Status
 .. image:: https://codecov.io/github/bear/bearlib/coverage.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20bearlib))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `bearlib`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.