### PR TITLE
Python3

### DIFF
--- a/bearlib/events.py
+++ b/bearlib/events.py
@@ -30,7 +30,13 @@ For example.py:
 
 import os
 import sys
-import imp
+
+try:
+    # python 3
+    from importlib import load_source
+except ImportError:
+    from imp import load_source
+
 
 _ourPath = os.getcwd()
 _ourName = os.path.splitext(os.path.basename(sys.argv[0]))[0]
@@ -46,7 +52,7 @@ class Events(object):
             for filename in filenames:
                 moduleName, moduleExt = os.path.splitext(os.path.basename(filename))
                 if moduleExt == '.py':
-                    module = imp.load_source(moduleName, os.path.join(self.handlersPath, filename))
+                    module = load_source(moduleName, os.path.join(self.handlersPath, filename))
                     if hasattr(module, 'setup'):
                         self.handlers[moduleName.lower()] = module
 

--- a/bearlib/tools.py
+++ b/bearlib/tools.py
@@ -7,7 +7,12 @@
 import os
 import types
 import logging
-from urlparse import urlparse
+
+try:
+    # python 3
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 
 def normalizeFilename(filename):

--- a/bearlib/tools.py
+++ b/bearlib/tools.py
@@ -34,7 +34,7 @@ def baseDomain(domain, includeScheme=True):
     return result
 
 def pidWrite(pidFile):
-    os.umask(077)  # set umask for pid
+    os.umask(0o77)  # set umask for pid
     with open(pidFile, "w") as f:
         f.write(str(os.getpid()))
 


### PR DESCRIPTION
Upgrades bearlib to python3 from python2, leaving backwards compatibility in-place

* imp library
* urlparse
* octal constant notation